### PR TITLE
Header.html (for inline CSS) and submodule updated.

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -131,45 +131,6 @@
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type | html }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
-<noscript>
-    <style>
-        #theme-toggle,
-        .top-link {
-            display: none;
-        }
-
-    </style>
-    {{- if (and (ne site.Params.defaultTheme "light") (ne site.Params.defaultTheme "dark")) }}
-    <style>
-        @media (prefers-color-scheme: dark) {
-            :root {
-                --theme: rgb(29, 30, 32);
-                --entry: rgb(46, 46, 51);
-                --primary: rgb(218, 218, 219);
-                --secondary: rgb(155, 156, 157);
-                --tertiary: rgb(65, 66, 68);
-                --content: rgb(196, 196, 197);
-                --hljs-bg: rgb(46, 46, 51);
-                --code-bg: rgb(55, 56, 62);
-                --border: rgb(51, 51, 51);
-            }
-
-            .list {
-                background: var(--theme);
-            }
-
-            .list:not(.dark)::-webkit-scrollbar-track {
-                background: 0 0;
-            }
-
-            .list:not(.dark)::-webkit-scrollbar-thumb {
-                border-color: var(--theme);
-            }
-        }
-
-    </style>
-    {{- end }}
-</noscript>
 
 {{- partial "extend_head.html" . -}}
 


### PR DESCRIPTION
 **Description** 
This pull request focused on inline CSS issues. And also includes submodule update.
 
 **Changes**

1. Updated header.html to remove inline CSS.
```
Deleted Inline-CSS entries already exist in other CSS.
a. Hugo-PaperMod\assets\css\includes\scroll-bar.css
b. Hugo-PaperMod\assets\css\core\theme-vars.css
```

2. Our submodule (Hugo-PaperMod) has been updated.

