### PR TITLE
Update production

### DIFF
--- a/content/install.md
+++ b/content/install.md
@@ -8,9 +8,9 @@ author: "Monal"
 
 |        | iOS                                                      | macOS                                                    | macOS (homebrew)                            |
 |--------|----------------------------------------------------------|----------------------------------------------------------|---------------------------------------------|
-| Stable | [App Store](https://apps.apple.com/app/id317711500)      | [App Store](https://apps.apple.com/app/id1637078500)     | brew install –cask monal                                            |
-| Beta   | [Testflight Invitation](https://testflight.apple.com/join/lLLlgHpB) | [Testflight Invitation](https://testflight.apple.com/join/tGH2m5vf) | brew tap homebrew/cask-versions<br>brew install --cask monal-beta |
-| Alpha  | upon request to [info@monal-im.org](mailto:info@monal-im.org)<br>Then download from our [alpha download site](https://downloads.monal-im.org/monal-im/alpha/)              |                                                          | brew tap monal-im/homebrew-monal-alpha<br>brew install --cask monal-alpha |
+| Stable | [App Store](https://apps.apple.com/app/id317711500)      | [App Store](https://apps.apple.com/app/id1637078500)     | brew install \-\-cask monal                                            |
+| Beta   | [Testflight Invitation](https://testflight.apple.com/join/lLLlgHpB) | [Testflight Invitation](https://testflight.apple.com/join/tGH2m5vf) | brew tap homebrew/cask-versions<br>brew install \-\-cask monal-beta |
+| Alpha  | upon request to [info@monal-im.org](mailto:info@monal-im.org)<br>Then download from our [alpha download site](https://downloads.monal-im.org/monal-im/alpha/)              |                                                          | brew tap monal-im/homebrew-monal-alpha<br>brew install \-\-cask monal-alpha |
 
 # Features
 Monal currently covers the following chat features:


### PR DESCRIPTION
Two consecutive dashes are automatically converted to an en-dash. Thus dashes should be escaped to prevent this behavior.