### PR TITLE
Build site WARN fix, submodule bump

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -48,6 +48,20 @@ params:
     buildExpired: false
     enableEmoji: true
 
+    editPost:
+        URL: "https://github.com/monal-im/monal-im.org/tree/staging/content"
+        Text: "Suggest Changes"
+        appendFilePath: true
+
+    assets:
+        disableHLJS: true
+        disableFingerprinting: false
+
+    cover:
+        hidden: false
+        hiddenInList: false
+        hiddenInSingle: true
+
     socialIcons:
         - name: github
           url: "https://github.com/monal-im/monal"
@@ -149,20 +163,7 @@ outputs:
         - RSS
         - JSON
 
-    editPost:
-        URL: "https://github.com/monal-im/monal-im.org/tree/staging/content"
-        Text: "Suggest Changes"
-        appendFilePath: true
-
-    assets:
-        disableHLJS: true
-        disableFingerprinting: false
-
-    cover:
-        hidden: false
-        hiddenInList: false
-        hiddenInSingle: true
-
+    
 taxonomies:
     category: categories
     tag: tags

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,83 @@
+{{- /* Deprecate site.Author.email in favor of site.Params.author.email */}}
+{{- $authorEmail := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+  {{- end }}
+{{- else }}
+  {{- with site.Author.email }}
+    {{- $authorEmail = . }}
+    {{- warnf "The author key in site configuration is deprecated. Use params.author.email instead." }}
+  {{- end }}
+{{- end }}
+
+{{- /* Deprecate site.Author.name in favor of site.Params.author.name */}}
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName  = . }}
+  {{- end }}
+{{- else }}
+  {{- with site.Author.name }}
+    {{- $authorName = . }}
+    {{- warnf "The author key in site configuration is deprecated. Use params.author.name instead." }}
+  {{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = site }}{{ end }}
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+{{- $pages = $pctx.RegularPages }}
+{{- else }}
+{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $limit := site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ if eq .Title site.Title }}{{ site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ site.Title }}</description>
+    {{- with site.Params.images }}
+    <image>
+      <title>{{ site.Title }}</title>
+      <url>{{ index . 0 | absURL }}</url>
+      <link>{{ index . 0 | absURL }}</link>
+    </image>
+    {{- end }}
+    <generator>Hugo -- gohugo.io</generator>
+    <language>{{ site.Language.LanguageCode }}</language>{{ with $authorEmail }}
+    <managingEditor>{{.}}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    {{- if and (ne .Layout `search`) (ne .Layout `archives`) }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ with .Description | html }}{{ . }}{{ else }}{{ .Summary | html }}{{ end -}}</description>
+      {{- if site.Params.ShowFullTextinRSS }}
+      {{ (printf "<![CDATA[%s]]>" .Content) | safeHTML }}
+      {{- end }}
+    </item>
+    {{- end }}
+    {{- end }}
+  </channel>
+</rss>

--- a/layouts/partials/index_profile.html
+++ b/layouts/partials/index_profile.html
@@ -32,7 +32,7 @@
         {{- end }}
         <h1>{{ .title | default site.Title | markdownify }}</h1>
         <span>{{ .subtitle | markdownify }}</span>
-        {{- partial "social_icons.html" site.Params.socialIcons -}}
+	{{- partial "social_icons.html" -}}
 
         {{- with .buttons }}
         <div class="buttons">

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -12,12 +12,14 @@
 {{- $scratch.Add "meta" (slice (i18n "words" .WordCount | default (printf "%d words" .WordCount))) }}
 {{- end }}
 
+{{- if not (.Param "hideAuthor") -}}
 {{- with (partial "author.html" .) }}
 {{- $scratch.Add "meta" (slice .) }}
 {{- end }}
+{{- end }}
 
 {{- with ($scratch.Get "meta") }}
-{{- delimit . "&nbsp;·&nbsp;" -}}
+{{- delimit . "&nbsp;·&nbsp;" | safeHTML -}}
 {{- end }}
 
 {{- if (.Param "ShowRssButtonInSectionTermList") -}}

--- a/layouts/shortcodes/implemented_features.html
+++ b/layouts/shortcodes/implemented_features.html
@@ -9,7 +9,7 @@
         </tr>
     </thead>
     {{ range .Project.implements }}
-        {{ if and (isset .SupportedXep "note") (ne .SupportedXep.status "wontfix") (ne .SupportedXep.status "planned") }}
+        {{ if and (default .SupportedXep.note) (ne .SupportedXep.status "wontfix") (ne .SupportedXep.status "planned") }}
             <tr>
                 <td>
                     <a href="{{ index .SupportedXep.xep "-resource" }}">

--- a/layouts/shortcodes/planned_features.html
+++ b/layouts/shortcodes/planned_features.html
@@ -8,7 +8,7 @@
         </tr>
     </thead>
     {{ range .Project.implements }}
-        {{ if and (isset .SupportedXep "note") (eq .SupportedXep.status "planned") }}
+        {{ if and (default .SupportedXep.note) (eq .SupportedXep.status "planned") }}
             <tr>
                 <td>
                     <a href="{{ index .SupportedXep.xep "-resource" }}">


### PR DESCRIPTION
 **Description** 
This pull request focused on resolving [WARNs](https://github.com/monal-im/monal-im.org/actions/runs/6926502262/job/18838760040#step:4:5) in the `Build Site` substep in the `buildAndDeploy` job. It also includes updates to the theme submodule.


 **Changes**

1. Relocated editpost, assets and cover parameters in config.yml file.
   - Error: `WARN Unknown kind "editpost" in outputs configuration.`

2. Fixed an issue that caused an error when using the [ShowFullTextinRSS](https://github.com/adityatelange/hugo-PaperMod/blob/master/layouts/_default/rss.xml#L77) parameter for updated version of RSS.xml.
   - Error: `namespace prefix content on encoded is not defined rss`

 3. Index_profile.html and post_meta.html files are synchronized with theme updates.
     - post_meta.html update also contains a fix for an issue that caused meta information (day, author and etc.) to be displayed incorrectly.  

![image](https://github.com/monal-im/monal-im.org/assets/69072094/dd485daa-2cb6-4a8d-a1bf-6d91e381c05c)

4. Updated implemented_features.html and planned_features.html files.
   - Error: `WARN  calling IsSet with unsupported type "invalid" (<nil>) will always return false.`

<details>
  <summary>Off Topic</summary>
By the way, all my best wishes for coming happy new year
</details>