### PR TITLE
Fix #61 and submodule changes sync

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,7 +27,7 @@ params:
     comments: false
     hidemeta: false
     searchHidden: false
-
+    weblate.svg: "https://hosted.weblate.org/widgets/monal/-/multi-auto.svg"
     defaultTheme: auto
     DateFormat: "02.01.2006"
     disableThemeToggle: false

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,10 +1,19 @@
 {{- if not (.Param "hideFooter") }}
 <footer class="footer">
-    {{- if site.Copyright }}
-    <span>{{ site.Copyright | markdownify }}</span>
-    {{- else }}
-    <span>&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ site.Title }}</a></span>
+    {{- if not site.Params.footer.hideCopyright }}
+        {{- if site.Copyright }}
+        <span>{{ site.Copyright | markdownify }}</span>
+        {{- else }}
+        <span>&copy; {{ now.Year }} <a href="{{ "" | absLangURL }}">{{ site.Title }}</a></span>
+        {{- end }}
+        {{- print " · "}}
     {{- end }}
+
+    {{- with site.Params.footer.text }}
+        {{ . | markdownify }}
+        {{- print " · "}}
+    {{- end }}
+    
     <span>
         Powered by
         <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &

--- a/layouts/shortcodes/remoteImage.html
+++ b/layouts/shortcodes/remoteImage.html
@@ -1,9 +1,14 @@
-{{ if .IsNamedParams }}
-  {{ $image := $.Page.Resources.GetMatch (.Get "name") }}
-  {{ $title := cond (not (.Get "title")) $image.title (.Get "title") }}
-  <img src="{{ $image.RelPermalink }}" title="{{ $title | safeHTML }}">
-{{ else }}
-  {{ $image := $.Page.Resources.GetMatch (.Get 0) }}
-  {{ $title := cond (not (.Get 1)) $image.title (.Get 1) }}
-  <img src="{{ $image.RelPermalink }}" title="{{ $title | safeHTML }}">
+{{ $paramName := .Get 0 }}                                                                  <!-- Get the shortcode argument -->
+{{ $paramValue := index .Site.Params $paramName }}                                          <!-- Get the parameter value from the config file -->
+
+{{ if $paramValue }}                                                                        <!-- If the parameter value exists -->
+  {{ $image := resources.GetRemote $paramValue }}                                           <!-- Fetch the image from the $Params link -->
+  {{ $alt := .Get "alt" }}                                                                  <!-- Get the alt text from the shortcode parameters -->
+  {{ $title := cond (not (.Get "title")) $alt (.Get "title") }}                             <!-- Set the title to alt text if title is not provided -->
+  <img src="{{ $image.RelPermalink | absURL | safeURL }}" title="{{ $title | safeHTML }}">  <!-- Display the image -->
+{{ else }}                                                                                  <!-- If the parameter value does not exist -->
+  {{ $image := resources.GetRemote (.Get 0) }}                                              <!-- Fetch the image from the remote source via link -->
+  {{ $alt := .Get "alt" }}                                                                  <!-- Get the alt text from the shortcode parameters -->
+  {{ $title := cond (not (.Get "title")) $alt (.Get "title") }}                             <!-- Set the title to alt text if title is not provided -->
+  <img src="{{ $image.RelPermalink | absURL | safeURL }}" title="{{ $title | safeHTML }}">  <!-- Display the image -->
 {{ end }}


### PR DESCRIPTION
 **Description** 
This pull request focused on remote image fetching --> caching --> and from local cache loading/serving support. Also includes  submodule theme changes.

 **Changes**

1. In `config.yml` file a parameter called weblate.svg has been added.

2. `remoteImage` shortcode has been updated according to the issue #61 and comment lines have been added for future reference. 

3. Modified `footer.html` file are synchronized with theme updates.

4. If nothing goes wrong, the remoteImage shortcode will work following this workflow:
![image](https://github.com/monal-im/monal-im.org/assets/69072094/c1aef3fa-6b7a-4c4e-865d-d675927a1a17)
