### PR TITLE
Github actions error fix, submodule updated

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -182,7 +182,7 @@ privacy:
     disabled: true
     simple: true
 
-  twitter:
+  x:
     disabled: true
     enableDNT: true
     simple: true
@@ -198,7 +198,7 @@ privacy:
 services:
   instagram:
     disableInlineCSS: true
-  twitter:
+  x:
     disableInlineCSS: true
 
 caches:

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -110,6 +110,4 @@
 
 {{- /* Misc */}}
 {{- if hugo.IsProduction | or (eq site.Params.env "production") }}
-{{- template "partials/templates/opengraph.html" . }}
-{{- template "partials/templates/schema_json.html" . }}
 {{- end -}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -33,7 +33,7 @@
             {{- end }}
             <div class="logo-switches">
                 {{- if (not site.Params.disableThemeToggle) }}
-                <button id="theme-toggle" accesskey="t" title="(Alt + T)">
+                <button id="theme-toggle" accesskey="t" title="(Alt + T)" aria-label="Toggle theme">
                     <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="18" viewBox="0 0 24 24"
                         fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
                         stroke-linejoin="round">


### PR DESCRIPTION
 **Description** 
This pull request is focused on warnings on [Github Actions](https://github.com/monal-im/monal-im.org/actions/runs/14404273434). Also includes submodule theme changes.

 **Short summary**

1. The issue `Error: error building site: html/template:_partials/head.html:114:13: no such template "partials/templates/schema_json.html"` fixed. The theme submodule has also been updated.

2. deprecated site config keys: `privacy.twitter.enableDNT`, `privacy.twitter.simple` and `services.twitter.disableInlineCSS` fixed before it was too late.


